### PR TITLE
Fixing Invalid Transition error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea
 
 # rspec failure tracking
 .rspec_status

--- a/spec/argon_spec.rb
+++ b/spec/argon_spec.rb
@@ -1144,7 +1144,7 @@ RSpec.describe Argon do
       instance.update_column(:state, 2)
       expect(instance.state).to eq :def
 
-      expect { instance.move! }.to raise_error(Argon::InvalidTransitionError, "Invalid state transition. SampleClass#1 cannot perform 'move' on state='abc'")
+      expect { instance.move! }.to raise_error(Argon::InvalidTransitionError, "Invalid state transition. SampleClass#1 cannot perform 'move' on state='def'")
     end
   end
 
@@ -1215,7 +1215,7 @@ RSpec.describe Argon do
       instance.update_column(:state, 2)
       expect(instance.state).to eq :def
 
-      expect { instance.move! }.to raise_error(Argon::InvalidTransitionError, "Invalid state transition. SampleClass#1 cannot perform 'move' on state='abc'")
+      expect { instance.move! }.to raise_error(Argon::InvalidTransitionError, "Invalid state transition. SampleClass#1 cannot perform 'move' on state='def'")
     end
   end
 


### PR DESCRIPTION
Only raising Invalid State Transition error once, to ensure simultaneous state transitions won't interfere with one another, and fixed error message to show the current state that's being transitioned away from.